### PR TITLE
Propose removal of conventional commit style

### DIFF
--- a/conboarding.md
+++ b/conboarding.md
@@ -36,9 +36,6 @@ Please note that some of the following links and resources are not publicly acce
       defaultBranch = main
    ```
 
-1. Use standard commit messages, see [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
-   (Also see [DataLad's commit conventions](https://github.com/datalad/datalad-core/blob/main/CONTRIBUTING.md#conventional-commits)
-
 1. Follow [REUSE Software spec](https://reuse.software/spec-3.3/) to ensure that licenses and
    copyright information are "comprehensive, unambiguous, human- and machine-readable".
 


### PR DESCRIPTION
I've noticed we really don't tend to enforce or even incidentally use this convention across various repos (within this org or DANDI)

OK to just remove?